### PR TITLE
Added compatibility and fixed multiplier attribute modifiers

### DIFF
--- a/src/main/java/com/redlimerl/detailab/mixins/EntityAttributeInstanceInvoker.java
+++ b/src/main/java/com/redlimerl/detailab/mixins/EntityAttributeInstanceInvoker.java
@@ -1,0 +1,15 @@
+package com.redlimerl.detailab.mixins;
+
+import java.util.Collection;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.entity.attribute.EntityAttributeInstance;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+
+@Mixin(EntityAttributeInstance.class)
+public interface EntityAttributeInstanceInvoker {
+	@Invoker("getModifiersByOperation")
+	public Collection<EntityAttributeModifier> invokeGetModifiersByOperation(EntityAttributeModifier.Operation operation);
+}

--- a/src/main/java/com/redlimerl/detailab/render/ArmorBarRenderer.java
+++ b/src/main/java/com/redlimerl/detailab/render/ArmorBarRenderer.java
@@ -1,10 +1,26 @@
 package com.redlimerl.detailab.render;
 
+import static com.redlimerl.detailab.DetailArmorBar.GUI_ARMOR_BAR;
+import static com.redlimerl.detailab.DetailArmorBar.getConfig;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.UUID;
+
 import com.google.common.collect.Multimap;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.redlimerl.detailab.DetailArmorBar;
 import com.redlimerl.detailab.api.DetailArmorBarAPI;
 import com.redlimerl.detailab.api.render.CustomArmorBar;
+import com.redlimerl.detailab.config.ConfigEnumType.Animation;
+import com.redlimerl.detailab.config.ConfigEnumType.ProtectionEffect;
+import com.redlimerl.detailab.mixins.EntityAttributeInstanceInvoker;
+
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.hud.InGameHud;
@@ -23,14 +39,6 @@ import net.minecraft.item.ArmorMaterials;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Pair;
 import net.minecraft.util.math.MathHelper;
-
-import java.awt.*;
-import java.util.List;
-import java.util.*;
-
-import static com.redlimerl.detailab.DetailArmorBar.*;
-import static com.redlimerl.detailab.config.ConfigEnumType.Animation;
-import static com.redlimerl.detailab.config.ConfigEnumType.ProtectionEffect;
 
 public class ArmorBarRenderer {
     static class LevelData {
@@ -150,17 +158,24 @@ public class ArmorBarRenderer {
 
         EntityAttributeInstance attribute = player.getAttributeInstance(EntityAttributes.GENERIC_ARMOR);
         if (attribute != null) {
-            for (int i = 0; i < attribute.getBaseValue(); i++) {
-                armorItem.add(new Pair<>(ItemStack.EMPTY, CustomArmorBar.DEFAULT));
-            }
-
-            for (EntityAttributeModifier entityAttributeModifier : attribute.getModifiers()) {
-                if (!Arrays.stream(MODIFIERS).toList().contains(entityAttributeModifier.getId())) {
-                    for (int i = 0; i < entityAttributeModifier.getValue(); i++) {
-                        armorItem.add(new Pair<>(ItemStack.EMPTY, CustomArmorBar.DEFAULT));
-                    }
-                }
-            }
+        	double d = attribute.getBaseValue();
+        	for (int i = 0; i < d; i++) {
+        		armorItem.add(new Pair<>(ItemStack.EMPTY, CustomArmorBar.DEFAULT));
+        	}
+        	
+        	for (EntityAttributeModifier modifier : ((EntityAttributeInstanceInvoker)attribute).invokeGetModifiersByOperation(EntityAttributeModifier.Operation.ADDITION)) {
+        		d += modifier.getValue();
+        		
+        		if (!Arrays.stream(MODIFIERS).toList().contains(modifier.getId())) {
+        			for (int i = 0; i < modifier.getValue(); i++) {
+                		armorItem.add(new Pair<>(ItemStack.EMPTY, CustomArmorBar.DEFAULT));
+                	}
+        		}
+        	}
+        	
+        	for (int i = 0; i < attribute.getValue() - d; i++) {
+        		armorItem.add(new Pair<>(ItemStack.EMPTY, CustomArmorBar.DEFAULT));
+        	}
         }
 
         for (ItemStack itemStack : equipment) {

--- a/src/main/resources/detailab.mixins.json
+++ b/src/main/resources/detailab.mixins.json
@@ -8,6 +8,7 @@
   "client": [
     "ArmorBarMixin",
     "ExperienceOrbEntityMixin",
-    "ThornsEnchantmentMixin"
+    "ThornsEnchantmentMixin",
+    "EntityAttributeInstanceInvoker"
   ]
 }


### PR DESCRIPTION
### 1. Changes

+Added compatibility with [PlayerEx](https://www.curseforge.com/minecraft/mc-mods/playerex) (but really [Data Attributes](https://www.curseforge.com/minecraft/mc-mods/data-attributes)).
*Fixed *very minor* issue with multiplier type entity attribute modifiers.

### 2. Problem Statement

#### 2.1. Incompatibility with PlayerEx

I was made aware of this incompatibility through [this](https://github.com/CleverNucleus/PlayerEx/issues/87) issue. Detail Armor Bar accounts for the armor attribute's base value and modifier values, which normally would be everything that contributes to the attribute's total value. However, Data Attributes (a dependency of PlayerEx) implements follow-on/secondary attributes - these are basically as follows: 

When you put a point into Constitution, for example, your Max Health increases by the same amount. This is not done through a modifier, but rather by taking the actual value of the Constitution attribute and including it when computing the value for Max Health. This is done through a parent-child attribute system, of which is crudely documented on the repository.

What this means is that the Armor provided by the Strength attribute is not reflected in the armor bar, because it is not technically a modifier nor part of the base value of the attribute.

#### 2.2 Issues with multiplier type attributes

The current code iterates through every armor modifier, and so long as the modifier's value is less than zero, armor is added to the bar. See [here](https://github.com/RedLime/DetailArmorBar/blob/0307785c104fcd2c2a6e3c54f070c3b072bcc669/src/main/java/com/redlimerl/detailab/render/ArmorBarRenderer.java#L157) and [here](https://github.com/RedLime/DetailArmorBar/blob/0307785c104fcd2c2a6e3c54f070c3b072bcc669/src/main/java/com/redlimerl/detailab/render/ArmorBarRenderer.java#L159).

Now this is totally fine really and I understand why it is done this way. In vanilla and indeed most modded circumstances there are no multiplier type modifiers for armor i.e. `MULTIPLY_BASE` and `MULTIPLY_TOTAL`. However, what this means is that when circumstances arise where there are such modifiers (namely with PlayerEx installed) you get modifiers like +22% Armor: this translates into a modifier value of 0.22. This value is greater than zero but less than one, so a single half armor is added to the bar. The reality is that if the player had 10 armor from a chestplate and helmet, that +22% armor modifier provides an extra 2 armor points, not 1. 

### 3. Solution

A single solution is implemented for both of the aforementioned issues: 

1. Instead of iterating through every modifier and checking if they are an armor piece, we loop through just the `ADDITION` type modifiers and check if they are an armor piece.
2. We add the total of the iterated `ADDITION` type modifiers (including armor pieces) and subtract it from the total attribute value: `attribute#getValue - sum_of_addition_modifiers`. The remainder is usually zero, but if there are multiplier type modifiers or PlayerEx/Data Attributes is installed, then the remainder is the sum of those values (note that the sum of the multiplier modifier type values refers to the *change in armor value __due to the modifier__*, not the modifier value itself, as multiplier modifier values are irrelevant by themselves).
3. To do this, we add a small `Invoker` mixin to `EntityAttributeInstance` to access `EntityAttributeInstance#getModifiersByOperation`.

I hope that this is acceptable, if any further explanation is wanted please let me know.
Thanks.
